### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Go
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/martinplaner/mp/security/code-scanning/2](https://github.com/martinplaner/mp/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow. Since the workflow only checks out code and runs build/test steps, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. This block can be added either at the root of the workflow (to apply to all jobs) or at the job level (to apply only to the `build` job). The best practice is to add it at the root, immediately after the `name` field, so all jobs inherit the least privilege unless overridden. No additional imports or definitions are needed; simply add the following block:

```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
